### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,5 +6,5 @@ The current maintainers of the Telepresence project are:
 * Rafael Schloming [rhs](https://github.com/rhs), <rhs@datawire.io>, core maintainer
 * Luke Shumaker [LukeShu](https://github.com/LukeShu), <lukeshu@datawire.io>, core maintainer
 * Richard Li [richarddli](https://github.com/richarddli), <richard@datawire.io>, documentation
-
+* Not a person 
 See [GOVERNANCE.md](GOVERNANCE.md) for governance guidelines and maintainer responsibilities.


### PR DESCRIPTION

---
Make sure every source file you touch has the standard license header.

Before landing, add a changelog entry as a file `newsfragments/issue_number.type`, where `type` is one of `incompat`, `feature`, `bugfix`, or `misc`. Preview the changelog with `virtualenv/bin/towncrier --draft`. 

E.g., `532.bugfix` would contain the text "Telepresence should no longer get confused looking for the route to the host when using the container method."
